### PR TITLE
Add jump links to reminders

### DIFF
--- a/GearBot/Cogs/Reminders.py
+++ b/GearBot/Cogs/Reminders.py
@@ -119,6 +119,10 @@ class Reminders(BaseCog):
         try:
             if location is None:
                 return False
+            if package.guild_id is None:
+                jumplink_available = "Unavailable"
+            else:
+                jumplink_available = MessageUtils.jumplink_construct(package.guild_id, package.channel_id, package.message_id)
             mode = "dm" if isinstance(location, User) else "channel"
             now = datetime.utcfromtimestamp(time.time())
             send_time = datetime.utcfromtimestamp(package.send.timestamp())
@@ -126,7 +130,7 @@ class Reminders(BaseCog):
                 "date": send_time.strftime('%c'),
                 "timediff": server_info.time_difference(now, send_time, None if isinstance(location, User) else location.guild.id),
                 "now_date": now.strftime('%c'),
-                "jump_link": MessageUtils.jumplink_construct(package.guild_id, package.channel_id, package.message_id),
+                "jump_link": jumplink_available,
                 "recipient": None if isinstance(location, User) else (await Utils.get_user(package.user_id)).mention
             }
             parcel = Translator.translate(f"reminder_delivery_{mode}", None if isinstance(location, User) else location, **parts)

--- a/GearBot/Cogs/Reminders.py
+++ b/GearBot/Cogs/Reminders.py
@@ -79,7 +79,8 @@ class Reminders(BaseCog):
             dm = True
         Reminder.create(user_id=ctx.author.id, channel_id=ctx.channel.id, dm=dm,
                         to_remind=await Utils.clean(reminder, markdown=False),
-                        time=time.time() + duration_seconds, status=ReminderStatus.Pending)
+                        time=time.time() + duration_seconds, status=ReminderStatus.Pending,
+                        guild_id=ctx.guild.id, message_id=ctx.message.id)
         mode = "dm" if dm else "here"
         await MessageUtils.send_to(ctx, "YES", f"reminder_confirmation_{mode}", duration=duration.length,
                                      duration_identifier=duration.unit)
@@ -125,6 +126,7 @@ class Reminders(BaseCog):
                 "date": send_time.strftime('%c'),
                 "timediff": server_info.time_difference(now, send_time, None if isinstance(location, User) else location.guild.id),
                 "now_date": now.strftime('%c'),
+                "jump_link": MessageUtils.jumplink_construct(package.guild_id, package.channel_id, package.message_id),
                 "recipient": None if isinstance(location, User) else (await Utils.get_user(package.user_id)).mention
             }
             parcel = Translator.translate(f"reminder_delivery_{mode}", None if isinstance(location, User) else location, **parts)

--- a/GearBot/Util/MessageUtils.py
+++ b/GearBot/Util/MessageUtils.py
@@ -78,3 +78,6 @@ async def try_edit(message, emoji: str, string_name: str, embed=None, **kwargs):
 def day_difference(a, b, location):
     diff = a - b
     return Translator.translate('days_ago', location, days=diff.days, date=a)
+
+def jumplink_construct(guild_id, channel_id, message_id):
+    return f"https://discordapp.com/channels/{guild_id}/{channel_id}/{message_id}"

--- a/GearBot/database/DatabaseConnector.py
+++ b/GearBot/database/DatabaseConnector.py
@@ -75,6 +75,8 @@ class Reminder(Model):
     id = PrimaryKeyField()
     user_id = BigIntegerField()
     channel_id = BigIntegerField()
+    guild_id = BigIntegerField()
+    message_id = BigIntegerField()
     dm = BooleanField()
     to_remind = CharField(max_length=1800, collation="utf8mb4_general_ci")
     send = TimestampField()

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -434,7 +434,7 @@
   "reminder_confirmation_dm": "Alright, I'll DM you for that in {duration} {duration_identifier}",
   "reminder_confirmation_here": "Alright, I'll ping you here for that in {duration} {duration_identifier}",
   "reminder_delivery_dm": "⏰ ***DRING DRING*** ⏰\n\n**Reminder delivery**:\nFrom: ME!\nTo: You're reading this, who do you think?\nScheduled: ``{date}`` ({timediff} ago)\nDelivered: right now (``{now_date}``)\nReminder:",
-  "reminder_delivery_channel": "⏰ ***DRING DRING*** ⏰\n\n**Reminder delivery**:\nFrom: ME!\nTo: {recipient} \nScheduled: ``{date}`` ({timediff} ago)\nDelivered: right now (``{now_date}``)\nReminder:",
+  "reminder_delivery_channel": "⏰ ***DRING DRING*** ⏰\n\n**Reminder delivery**:\nFrom: ME!\nTo: {recipient} \nScheduled: ``{date}`` ({timediff} ago)\nDelivered: right now (``{now_date}``)\nJump Link: {jump_link}\nReminder:",
   "remind_help": "Base command for reminders",
   "remind_me_help": "Schedule to be reminded about something",
   "already_cleaning": "I'm already cleaning here up in this channel, please wait until that's done before executing the clean command again",


### PR DESCRIPTION
This PR adds jump links to reminder deliveries, you'll need to execute these SQL statements however:
`ALTER TABLE reminder ADD guild_id BIGINT NOT NULL` - adds a guild id field to the table
`ALTER TABLE reminder ADD message_id BIGINT NOT NULL` - adds a message id field to the table

Then it should be good to go!

This also fixes https://github.com/gearbot/GearBot/issues/185