### PR TITLE
Lock the quote command to guilds only.

### DIFF
--- a/GearBot/Cogs/Basic.py
+++ b/GearBot/Cogs/Basic.py
@@ -80,6 +80,7 @@ class Basic(BaseCog):
 
 
     @commands.command()
+    @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
     async def quote(self, ctx: commands.Context, *, message:Message):
         """quote_help"""


### PR DESCRIPTION
This is done because currently it will error out trying to use quote in DMs.

it _can_ get fixed if a new converter is done and added a parameter to specify a channel ID, but up to @AEnterprise.