### PR TITLE
Allow trusted roles and users to post invites

### DIFF
--- a/GearBot/Cogs/Censor.py
+++ b/GearBot/Cogs/Censor.py
@@ -11,6 +11,17 @@ from Util.Matchers import INVITE_MATCHER
 
 
 async def censor_invite(ctx, code, server_name):
+    # Allow for users with a trusted role, or trusted users, to post invite links
+    trusted_roles = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_ROLES")
+    trusted_users = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_USERS")
+
+    if ctx.message.author.id in trusted_users:
+        return
+
+    for role in ctx.message.author.roles:
+        if role.id in trusted_roles:
+            return
+    
     ctx.bot.data["message_deletes"].add(ctx.message.id)
     clean_message = await clean_content().convert(ctx, ctx.message.content)
     clean_name = Utils.clean_user(ctx.message.author)

--- a/GearBot/Cogs/Censor.py
+++ b/GearBot/Cogs/Censor.py
@@ -12,15 +12,16 @@ from Util.Matchers import INVITE_MATCHER
 
 async def censor_invite(ctx, code, server_name):
     # Allow for users with a trusted role, or trusted users, to post invite links
-    trusted_roles = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_ROLES")
-    trusted_users = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_USERS")
+    if Configuration.get_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS") == True:
+        trusted_roles = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_ROLES")
+        trusted_users = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_USERS")
 
-    if ctx.message.author.id in trusted_users:
-        return
-
-    for role in ctx.message.author.roles:
-        if role.id in trusted_roles:
+        if ctx.message.author.id in trusted_users:
             return
+
+        for role in ctx.message.author.roles:
+            if role.id in trusted_roles:
+                return
     
     ctx.bot.data["message_deletes"].add(ctx.message.id)
     clean_message = await clean_content().convert(ctx, ctx.message.content)

--- a/GearBot/Cogs/Censor.py
+++ b/GearBot/Cogs/Censor.py
@@ -12,17 +12,9 @@ from Util.Matchers import INVITE_MATCHER
 
 async def censor_invite(ctx, code, server_name):
     # Allow for users with a trusted role, or trusted users, to post invite links
-    if Configuration.get_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS") == True:
-        trusted_roles = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_ROLES")
-        trusted_users = Configuration.get_var(ctx.guild.id, "PERMISSIONS", "TRUSTED_USERS")
+    if Configuration.get_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS") and Permissioncheckers.is_trusted(ctx.author):
+        return
 
-        if ctx.message.author.id in trusted_users:
-            return
-
-        for role in ctx.message.author.roles:
-            if role.id in trusted_roles:
-                return
-    
     ctx.bot.data["message_deletes"].add(ctx.message.id)
     clean_message = await clean_content().convert(ctx, ctx.message.content)
     clean_name = Utils.clean_user(ctx.message.author)

--- a/GearBot/Cogs/Serveradmin.py
+++ b/GearBot/Cogs/Serveradmin.py
@@ -234,20 +234,14 @@ class Serveradmin(BaseCog):
     @configure.command(name="censortrustedbypass")
     async def enable_trusted_bypass(self, ctx: commands.Context, enabled_status: bool):
         config_status = Configuration.get_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS")
-        
-        if enabled_status is None:
-            await ctx.send(f"{Translator.translate('missing_arg', ctx, arg='enabled')}")
 
-        if enabled_status == True:
-            message = MessageUtils.assemble(ctx, "YES", "features_enabled", count=1) + "Censor Trusted Bypass"
-        else:
-            message = MessageUtils.assemble(ctx, "YES", "features_disabled", count=1) + "Censor Trusted Bypass"
+        enabled_string = "enabled" if enabled_status else "disabled"
+        enabled_string = Translator.translate(enabled_string, ctx.guild.id)
+
+        message = MessageUtils.assemble(ctx, "YES", "censor_trusted_bypass", status=enabled_string)
 
         if enabled_status == config_status:
-            if enabled_status == True:
-                message = MessageUtils.assemble(ctx, "NO", "feature_already_enabled", count=1) + "Censor Trusted Bypass"
-            else:
-                message = MessageUtils.assemble(ctx, "NO", "feature_already_disabled", count=1) + "Censor Trusted Bypass"
+            message = MessageUtils.assemble(ctx, "NO", f"censor_trusted_bypass_unchanged", status=enabled_string)
         else:
             Configuration.set_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS", enabled_status)
 

--- a/GearBot/Cogs/Serveradmin.py
+++ b/GearBot/Cogs/Serveradmin.py
@@ -231,6 +231,28 @@ class Serveradmin(BaseCog):
     async def remove_from_whitelist(self, ctx: commands.Context, server:int):
         await remove_item(ctx, ServerHolder(server), "invite", list_name="whitelist", config_section="CENSORING")
 
+    @configure.command(name="censortrustedbypass")
+    async def enable_trusted_bypass(self, ctx: commands.Context, enabled_status: bool):
+        config_status = Configuration.get_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS")
+        
+        if enabled_status is None:
+            await ctx.send(f"{Translator.translate('missing_arg', ctx, arg='enabled')}")
+
+        if enabled_status == True:
+            message = MessageUtils.assemble(ctx, "YES", "features_enabled", count=1) + "Censor Trusted Bypass"
+        else:
+            message = MessageUtils.assemble(ctx, "YES", "features_disabled", count=1) + "Censor Trusted Bypass"
+
+        if enabled_status == config_status:
+            if enabled_status == True:
+                message = MessageUtils.assemble(ctx, "NO", "feature_already_enabled", count=1) + "Censor Trusted Bypass"
+            else:
+                message = MessageUtils.assemble(ctx, "NO", "feature_already_disabled", count=1) + "Censor Trusted Bypass"
+        else:
+            Configuration.set_var(ctx.guild.id, "CENSORING", "ALLOW_TRUSTED_BYPASS", enabled_status)
+
+        await ctx.send(message)
+
     @configure.group(aliases=["ignoredUsers"])
     async def ignored_users(self, ctx):
         """configure_ignored_users_help"""

--- a/GearBot/Util/Configuration.py
+++ b/GearBot/Util/Configuration.py
@@ -246,6 +246,9 @@ def v16(config):
         config["PERMISSIONS"][key] = config["ROLES"][key]
         del config["ROLES"][key]
 
+def v17(config):
+    config["CENSORING"]["ALLOW_TRUSTED_BYPASS"] = False
+
 
 def add_logging(config, *args):
     for cid, info in config["LOG_CHANNELS"].items():
@@ -269,7 +272,7 @@ def move_keys(config, section, *keys):
 
 
 # migrators for the configs, do NOT increase the version here, this is done by the migration loop
-MIGRATORS = [initial_migration, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16]
+MIGRATORS = [initial_migration, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17]
 
 
 async def initialize(bot: commands.Bot):

--- a/GearBot/Util/Permissioncheckers.py
+++ b/GearBot/Util/Permissioncheckers.py
@@ -35,7 +35,13 @@ def is_user(perm_type, member):
         return False
     if not hasattr(member, "roles"):
         return False
+
     roles = Configuration.get_var(member.guild.id, "PERMISSIONS", f"{perm_type}_ROLES")
+    users = Configuration.get_var(member.guild.id, "PERMISSIONS", f"{perm_type}_USERS")
+
+    if member.id in users:
+        return True
+
     for role in member.roles:
         if role.id in roles:
             return True

--- a/config/template.json
+++ b/config/template.json
@@ -1,5 +1,5 @@
 {
-	"VERSION": 16,
+	"VERSION": 17,
 	"GENERAL": {
 		"LANG": "en_US",
 		"PERM_DENIED_MESSAGE": true,
@@ -24,6 +24,7 @@
 	},
 	"CENSORING": {
 		"ENABLED": false,
+		"ALLOW_TRUSTED_BYPASS": false,
 		"WORD_BLACKLIST": [],
 		"INVITE_WHITELIST": []
 	},

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -276,6 +276,8 @@
   "automod_ban_failed": "[AUTOBAN FAILURE] AUTOBAN was triggered for {user} (``{user_id}``) but I don't have the BAN_MEMBERS permission required to actually ban them! Ban reason: ``{reason}``",
   "censored_message": "Censored message by {user} (``{user_id}``) in {channel}, blacklisted char sequence ``{sequence}`` is not allowed.\n```{message}```",
   "censor_message_failed": "Failed to censor a message by {user} (``{user_id}``), blacklisted char sequence `{sequence}` is not allowed but I was unable to remove it.\n```{message}\n```<{link}>",
+  "censor_trusted_bypass": "Censor Trusted Bypass has been {status}",
+  "censor_trusted_bypass_unchanged": "Trusted Censor Bypass is already {status}",
   "warning_dm": "You have been warned in **{server}**!",
   "dm_on_warn_msg_enabled": "People will now receive a DM from me when you warn them containing the warning (but not the moderator warning them)",
   "dm_on_warn_msg_disabled": "When a warning is issued it will only be stored and logged, the person will not be informed",


### PR DESCRIPTION
This PR allows for any user who is listed as a `TRUSTED_USER` or has a `TRUSTED_ROLE` to post invite links without being censored. 

It also had a config switch for this at the admin's choice with: `!configure censortrustedbypass <true/false>`

Disclaimer: I have no idea if this is the optimal solution, but this technically *works* and tweaks can be made to better fit with the rest of the configuration commands.

Resolves #195