### PR TITLE
Don't allow bots to be warned

### DIFF
--- a/GearBot/Cogs/Infractions.py
+++ b/GearBot/Cogs/Infractions.py
@@ -45,6 +45,10 @@ class Infractions(BaseCog):
                 message = MessageUtils.assemble(ctx, "THINK", "warn_to_feedback")
                 await Confirmation.confirm(ctx, message, on_yes=yes)
             else:
+                if member.bot:
+                    await MessageUtils.send_to(ctx, "THINK", "cant_warn_bot")
+                    return
+
                 i = InfractionUtils.add_infraction(ctx.guild.id, member.id, ctx.author.id, "Warn", reason)
                 name = Utils.clean_user(member)
                 await MessageUtils.send_to(ctx, 'YES', 'warning_added', user=name, inf=i.id)

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -584,6 +584,7 @@
   "inf_search_compiling": "Looking up things and stuff, I think",
   "inf_summary": "Infraction summary:",
   "warn": "Warning",
+  "cant_warn_bot": "Why are you trying to warn a bot? Maybe try contacting the bot author instead",
   "ban": "Ban",
   "forced ban": "Forced ban",
   "mute": "Mute",


### PR DESCRIPTION
Don't let users apply warnings to bots anymore, but instead ask them to reconsider their choice of action :)