### PR TITLE
Bug Fix for adding more than a specific # of react

### DIFF
--- a/GearBot/Util/ReactionManager.py
+++ b/GearBot/Util/ReactionManager.py
@@ -54,6 +54,8 @@ async def self_roles(bot, message, user_id, reaction, **kwargs):
         for i in range(10):
             if str(reaction) == str(Emoji.get_emoji(str(i+1))):
                 roles = Configuration.get_var(message.guild.id, "ROLES", "SELF_ROLES")
+                if (i + 1) > len(roles):
+                    return
                 role = message.channel.guild.get_role(roles[page_num*10 + i])
                 if role is None:
                     await Selfroles.validate_self_roles(bot, message.channel.guild)


### PR DESCRIPTION
GearBot was spitting out errors that was related to the selfroles. So Fox and I got to investigate the situation since it was causing quite a bit of the error explosion.

Turns out it was due to someone adding the number 5 to the reactions where there are four roles. This happens with any number (two on one role, three on two, etc.). Because of that GearBot did not know how to react to that as it is unable to find a role with that number.

So Fox told me about this fix, so I went ahead and tested it on my instance. It would appear that the bug has been existent for a month now (considering that I was running a month old's code and was able to repro the same bug).

 This should stop the bot from erroring out, and it should just remove the reaction instead. Additionally, the existing numbers should be working (they were when I tested this fix.)