### PR TITLE
Fix erroring when adding ignored users

### DIFF
--- a/GearBot/Cogs/Serveradmin.py
+++ b/GearBot/Cogs/Serveradmin.py
@@ -19,7 +19,7 @@ class ServerHolder(object):
         self.name = sid
 
 
-async def add_item(ctx, item, item_type, config_section="PERMISSIONS", list_name="roles"):
+async def add_item(ctx, item, item_type, list_name="roles", config_section="PERMISSIONS"):
     target = f"{item_type}_{list_name}".upper()
     roles = Configuration.get_var(ctx.guild.id, config_section, target)
     sname = list_name[:-1] if list_name[-1:] == "s" else list_name


### PR DESCRIPTION
This fixes a bug that occurs when adding users to the ignored users list.

The root cause stemmed from the parameters being out of order for how the trusted users additions expected them to be. I have tested this with other commands that use the `add_item()` function and they still work as intended.