### PR TITLE
Dashboard outage monitoring

### DIFF
--- a/GearBot/Cogs/DashLink.py
+++ b/GearBot/Cogs/DashLink.py
@@ -92,7 +92,9 @@ class DashLink(BaseCog):
                  Configuration.get_master_var('REDIS_PORT', 6379)),
                 encoding="utf-8", db=0, maxsize=2)  # size 2: one send, one receive
             self.bot.loop.create_task(self._receiver())
-            self.bot.loop.create_task(self.dash_monitor())
+
+            if Configuration.get_master_var("DASH_OUTAGE")["outage_detection"]:
+                self.bot.loop.create_task(self.dash_monitor())
             
             # Store the token so the dashboard can notify the bot owner if the bot goes offline
             await self.redis_link.set("bot_login_token", Configuration.get_master_var("LOGIN_TOKEN"))

--- a/GearBot/Cogs/DashLink.py
+++ b/GearBot/Cogs/DashLink.py
@@ -145,7 +145,7 @@ class DashLink(BaseCog):
                             print("We couldn't access the specified channel, the notification will not be sent!")
 
             # Wait a little bit longer so the dashboard has a chance to update before we check
-            await asyncio.sleep(2)
+            await asyncio.sleep(65)
 
     async def _handle(self, sender, message):
         try:

--- a/config/master.json.example
+++ b/config/master.json.example
@@ -1,6 +1,7 @@
 {
   "LOGIN_TOKEN": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
   "BOT_LOG_CHANNEL": 365908831328403456,
+  "MAX_API_OUTAGE_WARNINGS": 3,
   "CROWDIN_KEY": null,
   "DATABASE_HOST": "localhost",
   "DATABASE_NAME": "gearbot",
@@ -31,7 +32,5 @@
     "AntiSpam"
   ],
   "DOCS": true,
-  "DOG_KEY": "",
-  "CAT_KEY": "",
   "DISABLED_COMMANDS": []
 }

--- a/config/master.json.example
+++ b/config/master.json.example
@@ -1,7 +1,6 @@
 {
   "LOGIN_TOKEN": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
   "BOT_LOG_CHANNEL": 365908831328403456,
-  "MAX_API_OUTAGE_WARNINGS": 3,
   "CROWDIN_KEY": null,
   "DATABASE_HOST": "localhost",
   "DATABASE_NAME": "gearbot",
@@ -32,5 +31,27 @@
     "AntiSpam"
   ],
   "DOCS": true,
-  "DISABLED_COMMANDS": []
+  "DISABLED_COMMANDS": [],
+  "DASH_OUTAGE": {
+      "max_bot_outage_warnings": 1,
+      "dash_outage_channel": 999999999,
+      "dash_outage_pinged_roles": [],
+      "dash_outage_message": "The Dashboard went down! Please look into it!",
+      "dash_outage_embed": {
+        "title": "Dashboard Outage Detected",
+        "timestamp": "",
+        "color": "FF0000",
+        "description": "The Dashboard is suspected to be down, it hasn't responded in over 3 minutes!",
+        "author": {
+          "name": "Gearbot Dashboard Monitor"
+        },
+        "fields": [
+          {
+            "name": "Alert Count",
+            "value": "{warnings_sent}/{MAX_BOT_OUTAGE_WARNINGS}",
+            "inline": true
+          }
+        ]
+    }
+  }
 }

--- a/config/master.json.example
+++ b/config/master.json.example
@@ -33,6 +33,7 @@
   "DOCS": true,
   "DISABLED_COMMANDS": [],
   "DASH_OUTAGE": {
+      "outage_detection": false,
       "max_bot_outage_warnings": 1,
       "dash_outage_channel": 999999999,
       "dash_outage_pinged_roles": [],


### PR DESCRIPTION
This PR allows Gearbot to monitor the new Dashboard API for outages. If the dashboard can't be reached for a little over 3 minutes, then it alerts a specified channel with a user defined message and a embed.

This closes #176 as well.