### PR TITLE
Add / Remove Nickname

### DIFF
--- a/GearBot/Cogs/Moderation.py
+++ b/GearBot/Cogs/Moderation.py
@@ -103,6 +103,34 @@ class Moderation(BaseCog):
             await MessageUtils.send_to(ctx, "SPY", "seen_fail", user_id=user.id, user=Utils.clean_user(user))
         else:
             await MessageUtils.send_to(ctx, "EYES", "seen_success", user_id=user.id, user=Utils.clean_user(user), date=Object(messages[0].messageid).created_at)
+    
+    @commands.group(aliases=["nick"])
+    @commands.guild_only()
+    @commands.bot_has_permissions(manage_nicknames=True)
+    async def nickname(self, ctx: commands.Context):
+        """mod_nickname_help"""
+        if ctx.subcommand_passed is None:
+            await ctx.invoke(self.bot.get_command("help"), query="nickname")
+    
+    @nickname.command("add")
+    @commands.bot_has_permissions(manage_nicknames=True)
+    async def nickname_add(self, ctx, user: discord.Member, *, nick):
+        try:
+            await user.edit(nick=nick)
+        except discord.HTTPException as ex:
+            await MessageUtils.send_to(ctx, "NO", "mod_nickname_too_long", user_id=user.id, user=Utils.clean_user(user))
+        else:
+            await MessageUtils.send_to(ctx, "YES", "mod_nickname_update", user_id=user.id, user=Utils.clean_user(user), nick=nick)
+    
+    @nickname.command("remove")
+    @commands.bot_has_permissions(manage_nicknames=True)
+    async def nickname_remove(self, ctx, user: discord.Member):
+        if user.nick is None:
+            await MessageUtils.send_to(ctx, "WHAT", "mod_nickname_mia", user=Utils.clean_user(user))
+            return
+        else:
+            await user.edit(nick=None)
+            await MessageUtils.send_to(ctx, "YES", "mod_nickname_nuked", user_id=user.id, user=Utils.clean_user(user))
 
 
     @commands.group()

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -733,5 +733,10 @@
   "verification_no_perms": "Unable to set the requested verification level, I do not have the required permissions.",
   "verification_log": "{user} (``{user_id}``) set the verification level to {level} for ``{reason}``",
   "verification_set": "The server's verification level has been set to {level} for ``{reason}``",
-  "ban_not_found": "Not banned"
+  "ban_not_found": "Not banned",
+  "mod_nickname_help": "Base command for nickname.",
+  "mod_nickname_update": "Successfully updated {user} (``{user_id}``)'s nickname to {nick}!",
+  "mod_nickname_too_long": "I was not able to change {user} (``{user_id}``)'s nickname, either I exceeded the 32 characters limit.",
+  "mod_nickname_nuked": "I have removed {user} (``{user_id}``)'s nickname.",
+  "mod_nickname_mia": "What nickname? {user} currently does not have a nickname."
 }


### PR DESCRIPTION
This is the beginning of the add and removal of nicknames. 

Nickname / Nick add will add and edit the nickname to the user if they are in the server.

Nickname / Nick remove will remove the nickname from the user.

I've exhausted of what I am knowledgeable about but the commands are currently functional which is something that I'm happy about. 

Although, this set of commands are not complete because it's missing the role checks. So currently, if you try to add a nickname to someone that is above you, there will be an incorrect error message as there is no catch for the role hierarchy currently. 

I don't think there's anything else that needs to be corrected. It's just the permission system in terms of the role hierarchy that needs to be worked on. 