### PR TITLE
Add check for add_reactions permission

### DIFF
--- a/GearBot/Cogs/Reminders.py
+++ b/GearBot/Cogs/Reminders.py
@@ -29,7 +29,8 @@ class Reminders(BaseCog):
         """remind_help"""
         if ctx.invoked_subcommand is None:
             await ctx.invoke(self.bot.get_command("help"), query="remind")
-
+            
+    @commands.bot_has_permissions(add_reactions=True)
     @remind.command("me", aliases=["add", "m", "a"])
     async def remind_me(self, ctx, duration: Duration, *, reminder: ReminderText):
         """remind_me_help"""


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Fixes the bug report by webhp where GearBot spits out a 403 error when not having add reactions permission in the guild. (https://canary.discordapp.com/channels/365498559174410241/474303535153020969/655626715024064512)

**Migration**
N/A.

**Dependencies**
N/A
