### PR TITLE
Stop error clashing with feedback message

### DIFF
--- a/GearBot/Cogs/Infractions.py
+++ b/GearBot/Cogs/Infractions.py
@@ -55,7 +55,7 @@ class Infractions(BaseCog):
             await MessageUtils.send_to(ctx, 'NO', 'cant_warn_system_user')
             return
                         
-        if member.bot and member.id != self.bot.user.id:
+        if member.bot:
             await MessageUtils.send_to(ctx, "THINK", "cant_warn_bot")
             return
 

--- a/GearBot/Cogs/Infractions.py
+++ b/GearBot/Cogs/Infractions.py
@@ -49,6 +49,7 @@ class Infractions(BaseCog):
 
             message = MessageUtils.assemble(ctx, "THINK", "warn_to_feedback")
             await Confirmation.confirm(ctx, message, on_yes=yes)
+            return 
         
         if member.discriminator == '0000':
             await MessageUtils.send_to(ctx, 'NO', 'cant_warn_system_user')

--- a/GearBot/Cogs/Infractions.py
+++ b/GearBot/Cogs/Infractions.py
@@ -54,7 +54,7 @@ class Infractions(BaseCog):
             await MessageUtils.send_to(ctx, 'NO', 'cant_warn_system_user')
             return
                         
-        if member.bot:
+        if member.bot and member.id == self.bot.user.id:
             await MessageUtils.send_to(ctx, "THINK", "cant_warn_bot")
             return
 

--- a/GearBot/Cogs/Infractions.py
+++ b/GearBot/Cogs/Infractions.py
@@ -38,7 +38,7 @@ class Infractions(BaseCog):
     async def warn(self, ctx: commands.Context, member: discord.Member, *, reason: Reason):
         """warn_help"""
         # don't allow warning GearBot, get some feedback about issues instead
-        if member.id = self.bot.user.id:
+        if member.id == self.bot.user.id:
 
             async def yes():
                 channel = self.bot.get_channel(Configuration.get_master_var("inbox", 0))

--- a/GearBot/Cogs/Infractions.py
+++ b/GearBot/Cogs/Infractions.py
@@ -38,7 +38,7 @@ class Infractions(BaseCog):
     async def warn(self, ctx: commands.Context, member: discord.Member, *, reason: Reason):
         """warn_help"""
         # don't allow warning GearBot, get some feedback about issues instead
-        if member.id == self.bot.user.id:
+        if member.id = self.bot.user.id:
 
             async def yes():
                 channel = self.bot.get_channel(Configuration.get_master_var("inbox", 0))
@@ -54,7 +54,7 @@ class Infractions(BaseCog):
             await MessageUtils.send_to(ctx, 'NO', 'cant_warn_system_user')
             return
                         
-        if member.bot and member.id == self.bot.user.id:
+        if member.bot and member.id != self.bot.user.id:
             await MessageUtils.send_to(ctx, "THINK", "cant_warn_bot")
             return
 


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Stops showing an error when trying to warn GearBot as it should only display the give feedback message.

![Discord_6DMsfnJFY0](https://user-images.githubusercontent.com/47828274/80024424-f36b8880-84d6-11ea-9c93-16db39293420.png)

