### PR TITLE
Discord domain migrations

### DIFF
--- a/GearBot/Util/MessageUtils.py
+++ b/GearBot/Util/MessageUtils.py
@@ -84,4 +84,4 @@ def day_difference(a, b, location):
     return Translator.translate('days_ago', location, days=diff.days, date=a)
 
 def construct_jumplink(guild_id, channel_id, message_id):
-    return f"https://discordapp.com/channels/{guild_id}/{channel_id}/{message_id}"
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ While transparency is always a good thing, when another user's data is potential
 
 ## How to report
 
-- Contact AEnterprise#4693 (userid 106354106196570112) or BlackHoleFox#1527 (userid 105076359188979712) on Discord. You can find us on the [GearBot Discord Server](https://discordapp.com/invite/vddW3D9).
+- Contact AEnterprise#4693 (userid 106354106196570112) or BlackHoleFox#1527 (userid 105076359188979712) on Discord. You can find us on the [GearBot Discord Server](https://discord.com/invite/vddW3D9).
 - Alternatively you can report via email at: gearbot@gearbot.rocks
 - You will receive a reply confirming we received your report within 48h. If you do not get such confirmation it means the person you tried to contact is unavailable for some reason. Please try one of the other methods instead to make sure we receive your report.
 

--- a/docs/pages/03.docs/02.setup/01.adding_gearbot/doc.md
+++ b/docs/pages/03.docs/02.setup/01.adding_gearbot/doc.md
@@ -3,7 +3,7 @@ title: Adding GearBot
 ---
 # Adding the bot
 The first step is to add GearBot to the server and prepare a few things so he can work. If you click on the following link you can add him with the permissions he needs. Below is an explanation of why he needs what permissions if you don't want him to have all these permissions.
-[Click here to add GearBot](https://discordapp.com/oauth2/authorize?client_id=349977940198555660&scope=bot&permissions=1342565590).
+[Click here to add GearBot](https://discord.com/oauth2/authorize?client_id=349977940198555660&scope=bot&permissions=1342565590).
 
 # Permissions
 - Manage roles


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Please give some general info about the PR

Discord has recently switched their primary domain from discordapp.com to just discord.com

This PR switches some of the references over. It only updates those which are known to be safe i.e. discordapp.com to discord.com

**Migration**
If any migration is required for already setup instances please provide instructions/requirements here

Not directly as a result of this PR per se. However, it should help other instances with their migrations when the time comes.

**Dependencies**
If this requires any other PRs to be merged and deployed in other GearBot repositories please link them here

None known at this time. https://github.com/gearbot/Dashboard/pull/11 has a relation to this PR, but is not directly affected by it.