### PR TITLE
Censor group invites.

### DIFF
--- a/GearBot/Cogs/Censor.py
+++ b/GearBot/Cogs/Censor.py
@@ -61,10 +61,10 @@ class Censor(BaseCog):
                     invite: discord.Invite = await self.bot.fetch_invite(code)
                 except discord.NotFound:
                     await self.censor_invite(ctx, code, "INVALID INVITE")
+                    return
                 if invite.guild is None:
                     await self.censor_invite(ctx, code, "DM group")
                     censored = True
-                    return
                 else:
                     if invite.guild is None or (not invite.guild.id in guilds and invite.guild.id != message.guild.id):
                         await self.censor_invite(ctx, code, invite.guild.name)

--- a/GearBot/Cogs/Censor.py
+++ b/GearBot/Cogs/Censor.py
@@ -64,6 +64,7 @@ class Censor(BaseCog):
                 if invite.guild is None:
                     await self.censor_invite(ctx, code, "DM group")
                     censored = True
+                    return
                 else:
                     if invite.guild is None or (not invite.guild.id in guilds and invite.guild.id != message.guild.id):
                         await self.censor_invite(ctx, code, invite.guild.name)

--- a/GearBot/Cogs/Censor.py
+++ b/GearBot/Cogs/Censor.py
@@ -61,7 +61,7 @@ class Censor(BaseCog):
                     invite: discord.Invite = await self.bot.fetch_invite(code)
                 except discord.NotFound:
                     await self.censor_invite(ctx, code, "INVALID INVITE")
-                except KeyError:
+                if invite.guild is None:
                     await self.censor_invite(ctx, code, "DM group")
                     censored = True
                 else:


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Discord.py no longer throws a KeyError when fetching a group DM invite. This removes the ``except KeyError`` part and properly filters group DM invites.

**Migration**
None.

**Dependencies**
None.
